### PR TITLE
feat: 채용 공고 데이터 중복 저장 방지 로직 구현

### DIFF
--- a/src/main/java/com/example/Open_Position_Hub/db/JobPostingRepository.java
+++ b/src/main/java/com/example/Open_Position_Hub/db/JobPostingRepository.java
@@ -20,4 +20,6 @@ public interface JobPostingRepository extends JpaRepository<JobPostingEntity, Lo
 
     @Query("select distinct j.companyId from JobPostingEntity j where j.companyId is not null ")
     List<Long> findDistinctCompanyIds();
+
+    List<JobPostingEntity> findByCompanyId(Long companyId);
 }


### PR DESCRIPTION
## issue
- #87 

## 구현 사항
스크래핑한 채용 공고 데이터와 db에 저장된 채용 공고 데이터를 companyId와 detailUrl을 기준으로 비교해서 데이터 중복 저장 방지

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

## 참고 사항
