### PR TITLE
Fix: limit filter height

### DIFF
--- a/src/main/java/com/example/Open_Position_Hub/JobPostingService.java
+++ b/src/main/java/com/example/Open_Position_Hub/JobPostingService.java
@@ -134,12 +134,16 @@ public class JobPostingService {
 
         Map<String, List<String>> filters = new HashMap<>();
 
-        filters.put("titles", jobPostingRepository.findDistinctTitles());
+        filters.put("titles", jobPostingRepository.findDistinctTitles().stream()
+            .sorted()
+            .toList()
+        );
 
         filters.put("companyNames", jobPostingRepository.findDistinctCompanyIds().stream()
             .map(id -> companyRepository.findById(id)
                 .map(CompanyEntity::getName)
                 .orElseThrow(() -> new RuntimeException("Not Found Company By CompanyId while getFilterOptions.")))
+            .sorted()
             .toList()
         );
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -125,6 +125,7 @@
   <style>
     .scroll-box {
       min-height: 300px;
+      max-height: 400px;
       overflow-y: auto;
       border: 1px solid #ccc;
       padding: 5px;

--- a/src/test/java/com/example/Open_Position_Hub/collector/ManagerTest.java
+++ b/src/test/java/com/example/Open_Position_Hub/collector/ManagerTest.java
@@ -23,11 +23,11 @@ class ManagerTest {
     private Manager manager;
 
     private CompanyEntity doeat() {
-        return new CompanyEntity("doeat", "greeting", "https://teamdoeat.career.greetinghr.com/home#323ea93b-ce52-45c9-bbbf-0b85ad135508");
+        return new CompanyEntity("doeat", "그리팅", "https://teamdoeat.career.greetinghr.com/home#323ea93b-ce52-45c9-bbbf-0b85ad135508");
     }
 
     private CompanyEntity doodlin() {
-        return new CompanyEntity("doodlin", "greeting", "https://www.doodlin.co.kr/career#3276397a-a988-4ca5-ab47-9aa05e9cce30");
+        return new CompanyEntity("doodlin", "그리팅", "https://www.doodlin.co.kr/career#3276397a-a988-4ca5-ab47-9aa05e9cce30");
     }
 
     @Test


### PR DESCRIPTION
## issue
- #97 

## 구현 사항
필터 바 영역에 직무, 회사 옵션 영역에 최대 크기를 설정하고, 최대 크기를 넘어가면 스크롤이 생기는 것을 원했습니다. 그러나 생각대로 동작하지 않아 스크롤 박스 부분의 최대 크기를 설정했습니다.

추가하여 필터 옵션을 정렬된 상태로 보여주기 위해 필터 옵션을 db에서 읽어온 뒤 오름차순 정렬했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

## 참고 사항
