### PR TITLE
Feature: add dead link checker

### DIFF
--- a/src/main/java/com/example/Open_Position_Hub/OpenPositionHubApplication.java
+++ b/src/main/java/com/example/Open_Position_Hub/OpenPositionHubApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)

--- a/src/main/java/com/example/Open_Position_Hub/OpenPositionHubApplication.java
+++ b/src/main/java/com/example/Open_Position_Hub/OpenPositionHubApplication.java
@@ -7,7 +7,6 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerial
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 @EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public class OpenPositionHubApplication {
 

--- a/src/main/java/com/example/Open_Position_Hub/collector/Manager.java
+++ b/src/main/java/com/example/Open_Position_Hub/collector/Manager.java
@@ -62,7 +62,8 @@ public class Manager {
         Optional<Document> doc = scraper.fetchHtml(company.getRecruitmentUrl());
 
         if (doc.isPresent()) {
-            return platformRegistry.getStrategy(company.getRecruitmentPlatform()).scrape(doc.get(), company);
+            return platformRegistry.getStrategy(company.getRecruitmentPlatform())
+                .scrape(doc.get(), company);
         }
 
         return List.of();
@@ -112,11 +113,14 @@ public class Manager {
             logger.info("No deleted job postings.");
         }
     }
+
     @Scheduled(cron = "0 0 */3 * * *")
     public void check() {
 
         List<JobPostingEntity> jobPostingEntities = jobPostingRepository.findAll();
-        if (jobPostingEntities.isEmpty()) return;
+        if (jobPostingEntities.isEmpty()) {
+            return;
+        }
 
         Map<String, Long> checkUrlToEntityId = new HashMap<>(jobPostingEntities.size());
         List<JobPostingDto> jobPostingsForCheck = new ArrayList<>(jobPostingEntities.size());
@@ -144,10 +148,14 @@ public class Manager {
             ));
         }
 
-        if (jobPostingsForCheck.isEmpty()) return;
+        if (jobPostingsForCheck.isEmpty()) {
+            return;
+        }
 
         List<JobPostingDto> deadJobPostings = deadLinkChecker.checkDeadLinks(jobPostingsForCheck);
-        if (deadJobPostings.isEmpty()) return;
+        if (deadJobPostings.isEmpty()) {
+            return;
+        }
 
         List<Long> idsToDelete = deadJobPostings.stream()
             .map(d -> checkUrlToEntityId.get(d.detailUrl()))

--- a/src/main/java/com/example/Open_Position_Hub/collector/Manager.java
+++ b/src/main/java/com/example/Open_Position_Hub/collector/Manager.java
@@ -119,6 +119,47 @@ public class Manager {
         }
     }
 
+    /*
+    b=0, 18:00
+    b=1, 18:10
+    b=2, 18:20
+    b=3, 18:30
+    b=4, 18:40
+    b=5, 18:50
+    b=6, 19:00
+    b=7, 19:10
+    b=8, 19:20
+    b=9, 19:30
+    b=10, 19:40
+    b=11, 19:50
+    b=12, 20:00
+    b=13, 20:10
+    b=14, 20:20
+    b=15, 20:30
+    b=16, 20:40
+    b=17, 20:50
+    b=18, 21:00
+    b=19, 21:10
+    b=20, 21:20
+    b=21, 21:30
+    b=22, 21:40
+    b=23, 21:50
+    b=24, 22:00
+    b=25, 22:10
+    b=26, 22:20
+    b=27, 22:30
+    b=28, 22:40
+    b=29, 22:50
+    b=30, 23:00
+    b=31, 23:10
+    b=32, 23:20
+    b=33, 23:30
+    b=34, 23:40
+    b=35, 23:50
+
+    b=0, 6:00
+     */
+
     @Scheduled(cron = "0 */10 6-23 * * *", zone = "Asia/Seoul")
     public void check() {
         System.out.println("Start checking...");
@@ -138,6 +179,11 @@ public class Manager {
 
         for (JobPostingEntity j : jobPostingEntities) {
             CompanyEntity company = companyMap.get(j.getCompanyId());
+
+            if (company == null) {
+                logger.warn("[Manager - check] Company id {} not found.", j.getCompanyId());
+                continue;
+            }
 
             String checkUrl = buildRedirectUrl(company.getRecruitmentUrl(), j.getDetailUrl());
 

--- a/src/main/java/com/example/Open_Position_Hub/collector/Manager.java
+++ b/src/main/java/com/example/Open_Position_Hub/collector/Manager.java
@@ -53,7 +53,7 @@ public class Manager {
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     public void scrape() {
-        System.out.println("Processing...");
+        System.out.println("Start scraping...");
 //        List<CompanyEntity> companies = companyRepository.findAll();
         List<CompanyEntity> companies = companyRepository.findAllByRecruitmentPlatform("그리팅");
         companies.forEach(company -> saveJobPostings(processJobScraping(company)));
@@ -121,7 +121,7 @@ public class Manager {
 
     @Scheduled(cron = "0 */10 6-23 * * *", zone = "Asia/Seoul")
     public void check() {
-
+        System.out.println("Start checking...");
         int bucket = counterForCheck.getAndUpdate(c -> (c + 1) % 36);
 
         List<JobPostingEntity> jobPostingEntities = jobPostingRepository.findShard(36, bucket);
@@ -172,14 +172,18 @@ public class Manager {
             deleteChunk(idsToDelete, 500);
             logger.info("[Manager - check] Deleted {} dead postings", idsToDelete.size());
         }
+
+        System.out.println("Done!");
     }
 
     private String buildRedirectUrl(String recruitmentUrl, String detailUrl) {
         try {
             URI base = new URI(recruitmentUrl);
+            if (!base.getPath().endsWith("/")) {
+                base = base.resolve(base.getPath() + "/");
+            }
             URI detail = new URI(detailUrl);
-            URI total = base.resolve(detail);
-            return total.toString();
+            return base.resolve(detail).toString();
         } catch (URISyntaxException e) {
             throw new RuntimeException("Invalid BASE URL: " + recruitmentUrl + ", DETAIL: " + detailUrl, e.fillInStackTrace());
         }

--- a/src/main/java/com/example/Open_Position_Hub/collector/checker/DeadLinkChecker.java
+++ b/src/main/java/com/example/Open_Position_Hub/collector/checker/DeadLinkChecker.java
@@ -4,6 +4,8 @@ import com.example.Open_Position_Hub.collector.JobPostingDto;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.jsoup.Connection;
+import org.jsoup.Connection.Method;
 import org.jsoup.Connection.Response;
 import org.jsoup.Jsoup;
 import org.slf4j.Logger;
@@ -14,28 +16,49 @@ import org.springframework.stereotype.Component;
 public class DeadLinkChecker {
 
     private static final Logger logger = LoggerFactory.getLogger(DeadLinkChecker.class);
+    private static final String UA =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
+    private static final int TIMEOUT_MS = 3000;
 
     public List<JobPostingDto> checkDeadLinks(List<JobPostingDto> jobPostings) {
 
-        List<JobPostingDto> deadJobPostings = new ArrayList<>();
+        List<JobPostingDto> dead = new ArrayList<>();
 
-        for (JobPostingDto jobPosting : jobPostings) {
+        for (JobPostingDto j : jobPostings) {
             try {
-                if (!isAccessible(jobPosting.detailUrl())) {
-                    logger.warn("Dead links are not accessible {}", jobPosting.detailUrl());
-                    deadJobPostings.add(jobPosting);
+                if (!isAccessible(j.detailUrl())) {
+                    logger.warn("Dead link: {}", j.detailUrl());
+                    dead.add(j);
                 }
             } catch (IOException e) {
-                logger.error("[DeadLinkChecker] Error: {}", jobPosting.detailUrl(), e.fillInStackTrace());
+                try {
+                    if (!isAccessible(j.detailUrl())) {
+                        logger.warn("Dead links are not accessible {}", j.detailUrl());
+                        dead.add(j);
+                    }
+                } catch (IOException e1) {
+                    logger.error("[DeadLinkChecker] IOException on {}", j.detailUrl(), e.fillInStackTrace());
+                }
             }
         }
 
-        return deadJobPostings;
+        return dead;
     }
 
     private boolean isAccessible(String url) throws IOException {
 
-        Response response = Jsoup.connect(url).response();
-        return response.statusCode() == 200;
+        Connection base =  Jsoup.connect(url)
+            .userAgent(UA)
+            .timeout(TIMEOUT_MS)
+            .followRedirects(true)
+            .ignoreHttpErrors(true);
+
+        Response res = base.method(Method.HEAD).execute();
+        int code = res.statusCode();
+        if (code == 405 || code == 403) {
+            res = base.method(Method.GET).maxBodySize(64 * 1024).execute();
+            code = res.statusCode();
+        }
+        return code >= 200 && code < 300;
     }
 }

--- a/src/main/java/com/example/Open_Position_Hub/collector/checker/DeadLinkChecker.java
+++ b/src/main/java/com/example/Open_Position_Hub/collector/checker/DeadLinkChecker.java
@@ -35,8 +35,7 @@ public class DeadLinkChecker {
 
     private boolean isAccessible(String url) throws IOException {
 
-        Response response = null;
-        response = Jsoup.connect(url).response();
+        Response response = Jsoup.connect(url).response();
         return response.statusCode() == 200;
     }
 }

--- a/src/main/java/com/example/Open_Position_Hub/collector/checker/DeadLinkChecker.java
+++ b/src/main/java/com/example/Open_Position_Hub/collector/checker/DeadLinkChecker.java
@@ -1,0 +1,42 @@
+package com.example.Open_Position_Hub.collector.checker;
+
+import com.example.Open_Position_Hub.collector.JobPostingDto;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jsoup.Connection.Response;
+import org.jsoup.Jsoup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeadLinkChecker {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeadLinkChecker.class);
+
+    public List<JobPostingDto> checkDeadLinks(List<JobPostingDto> jobPostings) {
+
+        List<JobPostingDto> deadJobPostings = new ArrayList<>();
+
+        for (JobPostingDto jobPosting : jobPostings) {
+            try {
+                if (!isAccessible(jobPosting.detailUrl())) {
+                    logger.warn("Dead links are not accessible {}", jobPosting.detailUrl());
+                    deadJobPostings.add(jobPosting);
+                }
+            } catch (IOException e) {
+                logger.error("[DeadLinkChecker] Error: {}", jobPosting.detailUrl(), e.fillInStackTrace());
+            }
+        }
+
+        return deadJobPostings;
+    }
+
+    private boolean isAccessible(String url) throws IOException {
+
+        Response response = null;
+        response = Jsoup.connect(url).response();
+        return response.statusCode() == 200;
+    }
+}

--- a/src/main/java/com/example/Open_Position_Hub/config/SchedulingConfig.java
+++ b/src/main/java/com/example/Open_Position_Hub/config/SchedulingConfig.java
@@ -1,0 +1,12 @@
+package com.example.Open_Position_Hub.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@Profile("!test")
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/src/main/java/com/example/Open_Position_Hub/db/JobPostingRepository.java
+++ b/src/main/java/com/example/Open_Position_Hub/db/JobPostingRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JobPostingRepository extends JpaRepository<JobPostingEntity, Long> {
 
@@ -22,4 +23,7 @@ public interface JobPostingRepository extends JpaRepository<JobPostingEntity, Lo
     List<Long> findDistinctCompanyIds();
 
     List<JobPostingEntity> findByCompanyId(Long companyId);
+
+    @Query("select j from JobPostingEntity j where function('mod', j.id, :k) = :bucket")
+    List<JobPostingEntity> findShard(@Param("k") int k, @Param("bucket") int bucket);
 }

--- a/src/test/java/com/example/Open_Position_Hub/collector/ManagerTest.java
+++ b/src/test/java/com/example/Open_Position_Hub/collector/ManagerTest.java
@@ -1,13 +1,21 @@
 package com.example.Open_Position_Hub.collector;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.example.Open_Position_Hub.db.CompanyEntity;
 import com.example.Open_Position_Hub.db.CompanyRepository;
 import com.example.Open_Position_Hub.db.JobPostingRepository;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
@@ -51,6 +59,28 @@ class ManagerTest {
     void printDataSourceUrl() {
         System.out.println("🔍 spring.datasource.url = " + env.getProperty("spring.datasource.url"));
     }
+    @Autowired
+    ApplicationContext context;
+
+    @Test
+    void scheduling_should_be_disabled_in_test_profile() {
+        // 1) 스케줄러 등록 현황 수집
+        Collection<ScheduledTaskHolder> holders = context.getBeansOfType(ScheduledTaskHolder.class).values();
+        Set<ScheduledTask> tasks = holders.stream()
+            .flatMap(h -> h.getScheduledTasks().stream())
+            .collect(Collectors.toSet());
+
+        // 2) 조건: (a) 아예 홀더가 없거나, (b) 홀더는 있어도 등록된 작업이 0
+        boolean disabled = holders.isEmpty() || tasks.isEmpty();
+
+        // 3) 실패 시 어떤 작업이 잡혀 있었는지 보여주기 (toString()에 크론/딜레이 정보가 포함됨)
+        String debug = tasks.stream()
+            .map(Object::toString)
+            .collect(Collectors.joining("\n"));
+
+        assertTrue(disabled, () ->
+            "스케줄링이 활성화되어 있습니다. 등록된 작업:\n" + (debug.isBlank() ? "(없음)" : debug));
+    }
 
     @Test
     void test() {
@@ -58,6 +88,8 @@ class ManagerTest {
         companyRepository.saveAll(List.of(doeat(), gravityLabs(), doodlin(), gear2()));
 
         manager.scrape();
+
+        manager.check();
 
         jobPostingRepository.findAll().forEach(System.out::println);
 

--- a/src/test/java/com/example/Open_Position_Hub/collector/ManagerTest.java
+++ b/src/test/java/com/example/Open_Position_Hub/collector/ManagerTest.java
@@ -57,7 +57,7 @@ class ManagerTest {
 
         companyRepository.saveAll(List.of(doeat(), gravityLabs(), doodlin(), gear2()));
 
-        manager.process();
+        manager.scrape();
 
         jobPostingRepository.findAll().forEach(System.out::println);
 


### PR DESCRIPTION
## issue
- #130 

## 구현 사항
데드 링크 방지 기능 구현
10분마다 1/36 로 수집하여 db에 저장된 채용 공고를 샤딩해서 데드 링크 검사
최소 6시간마다 공고가 데드링크인지 검사한다. 

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

## 참고 사항
