### PR TITLE
feat: 회사의 채용 사이트 url 변경시 기존의 공고 데이터 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/Open_Position_Hub/db/JobPostingRepository.java
+++ b/src/main/java/com/example/Open_Position_Hub/db/JobPostingRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface JobPostingRepository extends JpaRepository<JobPostingEntity, Long> {
 
+    void deleteByCompanyIdIn(List<Long> companyIds);
+
     List<JobPostingEntity> findByCompanyId(Long companyId);
 
     @Query("select j from JobPostingEntity j where function('mod', j.id, :k) = :bucket")
     List<JobPostingEntity> findShard(@Param("k") int k, @Param("bucket") int bucket);
+
 }


### PR DESCRIPTION
## issue
- #148 

## 구현 사항
회사의 채용 사이트 url 변경 시 이미 db에 저장된 공고 데이터를 삭제한다.

이미 저장된 공고는 변경 전의 채용 사이트 url을 기준으로 동작하기 때문에 삭제한다. 그리고 다시 스크래핑 작업이 실행될 때, 공고가 수집 가능하다면 수집된다.

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

## 참고 사항
